### PR TITLE
4 cors issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ A Rust-based service for storing and querying cell tower location data. The serv
 
 ## Environment Variables
 
-| Variable             | Description                      | Example                             |
-| -------------------- | -------------------------------- | ----------------------------------- |
-| `DATABASE_URL`       | MySQL connection string          | `mysql://user:pass@localhost/cells` |
-| `RUST_LOG`           | Log level                        | `info`                              |
-| `OPENCELLID_API_KEY` | API key for OpenCelliD downloads | `your-api-key`                      |
+| Variable             | Description                                                                        | Example                                 |
+| -------------------- | ---------------------------------------------------------------------------------- | --------------------------------------- |
+| `DATABASE_URL`       | MySQL connection string                                                            | `mysql://user:pass@localhost/cells`     |
+| `RUST_LOG`           | Log level                                                                          | `info`                                  |
+| `OPENCELLID_API_KEY` | API key for OpenCelliD downloads                                                   | `your-api-key`                          |
+| `CORS_ORIGINS`       | Comma-separated list of allowed CORS origins (if not set, all origins are allowed) | `https://example.com,https://other.com` |
 
 ## Getting Started
 

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub traces_endpoint: Option<String>,
     pub port: u16,
     pub bind: Ipv4Addr,
+    pub cors_origin: Option<String>,
 }
 
 // Initialize dotenv and config only once
@@ -35,6 +36,7 @@ pub static CONFIG: Lazy<Config> = Lazy::new(|| {
         traces_endpoint: get_non_empty_env_var("OTEL_TRACES_COLLECTOR_URL"),
         port: parse_env_var::<u16>("PORT").unwrap_or(3000),
         bind: parse_env_var::<Ipv4Addr>("BIND").unwrap_or(Ipv4Addr::new(0, 0, 0, 0)),
+        cors_origin: get_non_empty_env_var("CORS_ORIGIN"),
     }
 });
 

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -15,7 +15,7 @@ pub struct Config {
     pub traces_endpoint: Option<String>,
     pub port: u16,
     pub bind: Ipv4Addr,
-    pub cors_origin: Option<String>,
+    pub cors_origins: Vec<String>,
 }
 
 // Initialize dotenv and config only once
@@ -36,7 +36,9 @@ pub static CONFIG: Lazy<Config> = Lazy::new(|| {
         traces_endpoint: get_non_empty_env_var("OTEL_TRACES_COLLECTOR_URL"),
         port: parse_env_var::<u16>("PORT").unwrap_or(3000),
         bind: parse_env_var::<Ipv4Addr>("BIND").unwrap_or(Ipv4Addr::new(0, 0, 0, 0)),
-        cors_origin: get_non_empty_env_var("CORS_ORIGIN"),
+        cors_origins: get_non_empty_env_var("CORS_ORIGINS")
+            .map(|s| s.split(',').map(|o| o.trim().to_string()).collect())
+            .unwrap_or_default(),
     }
 });
 

--- a/src/utils/server.rs
+++ b/src/utils/server.rs
@@ -16,7 +16,9 @@ pub fn health_route() -> impl Filter<Extract = impl warp::Reply, Error = warp::R
 /// If CORS_ORIGINS is set, only those origins are allowed.
 /// If CORS_ORIGINS is not set or empty, all origins are allowed.
 pub fn cors_filter(cors_origins: Vec<String>) -> Cors {
-    let cors = warp::cors().allow_methods(vec!["GET", "OPTIONS"]);
+    let cors = warp::cors()
+        .allow_methods(vec!["GET", "OPTIONS"])
+        .allow_headers(vec!["Content-Type"]);
 
     if cors_origins.is_empty() {
         debug!("CORS configured to allow any origin");


### PR DESCRIPTION
This pull request adds configurable Cross-Origin Resource Sharing (CORS) support to the service, allowing you to restrict which origins can access the API based on an environment variable. The main changes include updating configuration handling, introducing a new CORS filter, and applying it to the server routes.

Configuration and environment variable support:

* Added a new `CORS_ORIGINS` environment variable to the documentation and the `Config` struct, allowing a comma-separated list of allowed origins to be specified. If not set, all origins are allowed. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R27) [[2]](diffhunk://#diff-2b7c5f193ed6bee079db199a91efe8aaad58dbf46aa585c159043f00891b1865R18) [[3]](diffhunk://#diff-2b7c5f193ed6bee079db199a91efe8aaad58dbf46aa585c159043f00891b1865R39-R41)

CORS implementation in the server:

* Introduced a `cors_filter` function that builds a CORS filter using the configured origins and applies it to all routes. If no origins are specified, any origin is allowed. [[1]](diffhunk://#diff-684e5c9775683b053345286c9e7c8c2390d27b84d7970e580156d3d59fdb3b7cL2-R2) [[2]](diffhunk://#diff-684e5c9775683b053345286c9e7c8c2390d27b84d7970e580156d3d59fdb3b7cR15-R39)
* Updated the server startup logic to use the new CORS filter, ensuring all GET and OPTIONS requests respect the configured CORS policy.