### PR TITLE
Reorder primary key to optimize queries without radio filter

### DIFF
--- a/migrations/2026-01-08-141836-0000_reorder_primary_key/down.sql
+++ b/migrations/2026-01-08-141836-0000_reorder_primary_key/down.sql
@@ -1,0 +1,3 @@
+-- Revert to original primary key order
+ALTER TABLE cells DROP PRIMARY KEY,
+    ADD PRIMARY KEY (radio, mcc, net, area, cell);

--- a/migrations/2026-01-08-141836-0000_reorder_primary_key/up.sql
+++ b/migrations/2026-01-08-141836-0000_reorder_primary_key/up.sql
@@ -1,0 +1,5 @@
+-- Reorder primary key to optimize queries without radio filter
+-- New order: (mcc, net, area, cell, radio) instead of (radio, mcc, net, area, cell)
+
+ALTER TABLE cells DROP PRIMARY KEY,
+    ADD PRIMARY KEY (mcc, net, area, cell, radio);


### PR DESCRIPTION
This pull request updates the primary key order in the `cells` table to optimize query performance, especially for queries that do not filter by the `radio` column. The migration includes both an upgrade and a downgrade path.

**Database migration changes:**

* Reorders the primary key columns in the `cells` table from `(radio, mcc, net, area, cell)` to `(mcc, net, area, cell, radio)` to improve query efficiency when filtering without `radio`.
* Provides a down migration to revert the primary key order back to the original if necessary.